### PR TITLE
fix: IE11 compatibility issue

### DIFF
--- a/src/core/moduleLoader.js
+++ b/src/core/moduleLoader.js
@@ -187,7 +187,7 @@ export default function moduleLoaderFactory(requiredModules, validate, specs) {
                         return Promise
                             .all( amdModules.map( module => (
                                 //eslint-disable
-                                import(/* webpackIgnore: true */ `${module}`)
+                                import( `${module}`)
                                 //eslint-enable
                             )))
                             .then( loadedModules => Promise.resolve(...loadModules) );


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/RO-340
**Description:** `webpackIgnore: true` causes `import` usage in minified files, which makes it incompatible with IE11