### PR TITLE
Feature/TR 2731/request error status property

### DIFF
--- a/src/core/request.js
+++ b/src/core/request.js
@@ -33,7 +33,6 @@
  */
 import $ from 'jquery';
 import _ from 'lodash';
-import __ from 'i18n';
 import module from 'module';
 import context from 'context';
 import promiseQueue from 'core/promiseQueue';
@@ -258,7 +257,7 @@ export default function request(options) {
                                 reject(
                                     createError(
                                         response,
-                                        __('The server has sent an empty response'),
+                                        'The server has sent an empty response',
                                         xhr.status,
                                         xhr.readyState > 0
                                     )
@@ -312,8 +311,7 @@ export default function request(options) {
                         code: xhr.status,
                         sent: xhr.readyState > 0,
                         type: 'error',
-                        textStatus: textStatus,
-                        message: errorThrown || __('An error occurred!')
+                        textStatus: textStatus
                     };
 
                     const enhancedResponse = Object.assign({}, responseExtras, response);

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -25,7 +25,7 @@
  *   - the responseBody:
  *      { success : true, data : [the results]}
  *      { success : false, data : {Exception}, message : 'Something went wrong' }
- *      { success : false, code : X, message : 'Something went wrong' }
+ *      { success : false, errorCode : X, message : 'Something went wrong' }
  *   - 204 for empty content
  *   - 403 if CSRF token validation fails
  *
@@ -49,12 +49,23 @@ const queue = promiseQueue();
 const logger = loggerFactory('core/request');
 
 /**
+ * @typedef RequestErrorCustomFields
+ * @property {Object} response - the server body response as plain object
+ * @property {Boolean} sent - the sent status of http request
+ * @property {String} source
+ * @property {Number} code - the response HTTP code
+ * @property {Number} status - the response HTTP code (for backwards-compatibility, can use both `code` or `status` property, they are identical)
+ */
+/**
+ * @typedef {Error & RequestErrorCustomFields} RequestError
+ */
+/**
  * Create a new error based on the given response
  * @param {Object} response - the server body response as plain object
  * @param {String} fallbackMessage - the error message in case the response isn't correct
  * @param {Number} httpCode - the response HTTP code
  * @param {Boolean} httpSent - the sent status
- * @returns {Error} the new error
+ * @returns {RequestError} the new error
  */
 const createError = (response, fallbackMessage, httpCode, httpSent) => {
     let err;
@@ -69,6 +80,7 @@ const createError = (response, fallbackMessage, httpCode, httpSent) => {
 
     if (_.isNumber(httpCode)) {
         err.code = httpCode;
+        err.status = httpCode;
     }
     return err;
 };
@@ -88,7 +100,7 @@ const createError = (response, fallbackMessage, httpCode, httpSent) => {
  * @param {Number}  [options.timeout] - timeout in seconds for the AJAX request
  * @param {Object} [options.jwtTokenHandler] - JWT token handler instance
  * @param {string} [options.logLevel] - Minimum log level for request
- * @returns {Promise} resolves with response, or reject if something went wrong
+ * @returns {Promise} resolves with response, or reject with {@link RequestError} if something went wrong
  */
 export default function request(options) {
     // Allow external config to override user option

--- a/test/core/logger/api/test.js
+++ b/test/core/logger/api/test.js
@@ -138,7 +138,7 @@ QUnit.module('providers', function(hooks) {
             assert.ok(false, 'The method should not resolve');
             ready();
         }).catch(function(err) {
-            assert.ok(err instanceof TypeError, 'The given provider is not a logger');
+            assert.ok(err instanceof Error, 'The given provider is not a logger');
             ready();
         });
     });

--- a/test/core/request/test.js
+++ b/test/core/request/test.js
@@ -625,6 +625,7 @@ QUnit.cases
                     .catch(function(error) {
                         var expected = errors[caseData.url];
                         assert.equal(error.code, expected.code, 'The correct error code');
+                        assert.equal(error.status, expected.code, 'The correct error status');
                         assert.equal(error.sent, expected.sent, 'The correct error sent status');
                         assert.equal(error.source, expected.source, 'The correct error source');
                         assert.equal(error.message, expected.message, 'The correct error message');
@@ -804,7 +805,8 @@ QUnit.test('Token refreshing and retry only one time after 401', function(assert
         assert.equal(setAccessTokenResponse, true, 'access token stored successfully');
         assert.equal(setRefreshTokenResponse, true, 'refresh token stored successfully');
         request({ url: '//endpoint', jwtTokenHandler: this.handler, noToken: true }).catch(error => {
-            assert.equal(error.response.code, 401, 'should get back original status code');
+            assert.equal(error.response.code, 401, 'should get back original status (code)');
+            assert.equal(error.response.status, 401, 'should get back original status (status)');
             assert.deepEqual(error.response.error, originalError.error, 'should get back original api error');
             done();
         });
@@ -852,7 +854,8 @@ QUnit.test('Get back original error, if token refresh was not success', function
         assert.equal(setAccessTokenResponse, true, 'access token stored successfully');
         assert.equal(setRefreshTokenResponse, true, 'refresh token stored successfully');
         request({ url: '//endpoint', jwtTokenHandler: this.handler, noToken: true }).catch(error => {
-            assert.equal(error.response.code, 401, 'should get back original status code');
+            assert.equal(error.response.code, 401, 'should get back original status (code)');
+            assert.equal(error.response.status, 401, 'should get back original status (status)');
             assert.deepEqual(error.response.error, originalError.error, 'should get back original api error');
             done();
         });


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-2731

Use with https://github.com/oat-sa/test-taker-portal/pull/82

`test-taker-portal` thinks that http code is passed in `error.status`. But it's passed in `error.code`. Looks like it has never worked since the change to JWT authorization in https://github.com/oat-sa/test-taker-portal/pull/49 .

Looks like `error.code` isn't used by any other repo, but I can't be 100% sure, so I left it. 